### PR TITLE
Improve asset loading error handling with anyhow

### DIFF
--- a/crates/essential/src/assets/asset_loader.rs
+++ b/crates/essential/src/assets/asset_loader.rs
@@ -13,5 +13,5 @@ pub trait AssetLoader: Send + Sync + 'static {
         path: AssetPath<'static>,
         load_context: &mut AssetLoadContext,
         usage_setting: <Self::Asset as LoadableAsset>::UsageSettings,
-    ) -> Result<Self::Asset, ()>;
+    ) -> anyhow::Result<Self::Asset>;
 }

--- a/crates/essential/src/assets/asset_server.rs
+++ b/crates/essential/src/assets/asset_server.rs
@@ -165,6 +165,7 @@ impl AssetServer {
 
         let server = self.clone();
         let task = LoadTaskPool::get_or_init(TaskPool::new).spawn(async move {
+            let log_path = path.clone();
             let asset = asset_loader
                 .load(path, &mut AssetLoadContext::new(server), usage_settings)
                 .await;
@@ -174,7 +175,13 @@ impl AssetServer {
                         .send(AssetLoadEvent::Loaded(LoadedAsset::new(id, asset)))
                         .unwrap();
                 }
-                Err(_) => {
+                Err(error) => {
+                    log::error!(
+                        "Failed to load asset '{}' (type {}): {:#}",
+                        log_path.to_path().display(),
+                        std::any::type_name::<A>(),
+                        error
+                    );
                     sender.send(AssetLoadEvent::LoadFailed(id)).unwrap();
                 }
             }

--- a/crates/essential/src/assets/utils.rs
+++ b/crates/essential/src/assets/utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use cfg_if::cfg_if;
 
 use super::AssetPath;
@@ -12,47 +13,51 @@ fn format_url<'a>(path: AssetPath<'a>) -> reqwest::Url {
     base.join(path.to_string()).unwrap()
 }
 
-pub async fn load_to_string<'a>(path: AssetPath<'a>) -> Result<String, ()> {
+pub async fn load_to_string<'a>(path: AssetPath<'a>) -> anyhow::Result<String> {
     cfg_if! {
         if #[cfg(target_arch = "wasm32")] {
             let url = format_url(path);
-            let txt = reqwest::get(url)
+            let txt = reqwest::get(url.clone())
                 .await
-                .map_err(|_| ())?
+                .with_context(|| format!("HTTP request for asset '{}' failed", url))?
                 .text()
                 .await
-                .map_err(|_| ())?;
+                .with_context(|| format!("failed to read response body for asset '{}'", url))?;
         } else {
-            let path = std::env::current_exe().unwrap().parent().unwrap()
-                .join(path.normalized_path);
-            let txt = std::fs::read_to_string(&path).map_err(|_|
-                {
-                    println!("Failed to load file: {}", &path.display());
-                })?;
+            let exe_path = std::env::current_exe()
+                .context("could not determine executable path")?;
+            let exe_dir = exe_path
+                .parent()
+                .context("could not determine executable directory")?;
+            let path = exe_dir.join(path.normalized_path);
+            let txt = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read file '{}'", path.display()))?;
         }
     }
 
     Ok(txt)
 }
 
-pub async fn load_binary<'a>(path: AssetPath<'a>) -> Result<Vec<u8>, ()> {
+pub async fn load_binary<'a>(path: AssetPath<'a>) -> anyhow::Result<Vec<u8>> {
     cfg_if! {
         if #[cfg(target_arch = "wasm32")] {
             let url = format_url(path);
-            let data = reqwest::get(url)
+            let data = reqwest::get(url.clone())
                 .await
-                .map_err(|_| ())?
+                .with_context(|| format!("HTTP request for asset '{}' failed", url))?
                 .bytes()
                 .await
-                .map_err(|_| ())?
+                .with_context(|| format!("failed to read response body for asset '{}'", url))?
                 .to_vec();
         } else {
-            let path = std::env::current_exe().unwrap().parent().unwrap()
-                .join(path.normalized_path);
-            let data = std::fs::read(&path).map_err(|_|
-                {
-                    println!("Failed to load file: {}", &path.display());
-                })?;
+            let exe_path = std::env::current_exe()
+                .context("could not determine executable path")?;
+            let exe_dir = exe_path
+                .parent()
+                .context("could not determine executable directory")?;
+            let path = exe_dir.join(path.normalized_path);
+            let data = std::fs::read(&path)
+                .with_context(|| format!("failed to read file '{}'", path.display()))?;
         }
     }
 

--- a/crates/gltf-loader/Cargo.toml
+++ b/crates/gltf-loader/Cargo.toml
@@ -10,6 +10,7 @@ essential = { path = "../essential" }
 ecs = { path = "../ecs" }
 render = { path = "../render" }
 gltf = { version = "1.4.1" }
+anyhow = "1.0.97"
 async-trait = "0.1.50"
 glam = { version = "0.30.1" }
 log = "0.4.27"

--- a/crates/gltf-loader/src/loader.rs
+++ b/crates/gltf-loader/src/loader.rs
@@ -10,6 +10,7 @@ use animation::{
     root::AnimationRootBone,
     target::AnimationTarget,
 };
+use anyhow::{bail, Context};
 use async_trait::async_trait;
 use ecs::{
     command::CommandQueue,
@@ -116,8 +117,9 @@ impl AssetLoader for GLTFLoader {
         path: essential::assets::AssetPath<'static>,
         load_context: &mut essential::assets::asset_server::AssetLoadContext,
         usage_setting: <Self::Asset as essential::assets::LoadableAsset>::UsageSettings,
-    ) -> Result<Self::Asset, ()> {
-        let (document, buffers, images) = gltf::import(path.to_path()).unwrap();
+    ) -> anyhow::Result<Self::Asset> {
+        let (document, buffers, images) = gltf::import(path.to_path())
+            .with_context(|| format!("failed to import GLTF file '{}'", path.to_path().display()))?;
 
         let nodes = document
             .nodes()
@@ -125,26 +127,9 @@ impl AssetLoader for GLTFLoader {
             .collect();
 
         let mut textures = Vec::new();
-        for data in images {
-            let image = match data.format {
-                gltf::image::Format::R8 => image::DynamicImage::ImageLuma8(
-                    ImageBuffer::from_vec(data.width, data.height, data.pixels)
-                        .expect("Out of memory loading image."),
-                ),
-                gltf::image::Format::R8G8 => image::DynamicImage::ImageLumaA8(
-                    ImageBuffer::from_vec(data.width, data.height, data.pixels)
-                        .expect("Out of memory loading image."),
-                ),
-                gltf::image::Format::R8G8B8 => image::DynamicImage::ImageRgb8(
-                    ImageBuffer::from_vec(data.width, data.height, data.pixels)
-                        .expect("Out of memory loading image."),
-                ),
-                gltf::image::Format::R8G8B8A8 => image::DynamicImage::ImageRgba8(
-                    ImageBuffer::from_vec(data.width, data.height, data.pixels)
-                        .expect("Out of memory loading image."),
-                ),
-                _ => panic!("Image format usupported (for now)"),
-            };
+        for (image_index, data) in images.into_iter().enumerate() {
+            let image = GLTFLoader::dynamic_image_from_gltf(data)
+                .with_context(|| format!("failed to load GLTF image at index {}", image_index))?;
             let texture = Texture::from_dynamic_image(image);
             textures.push(load_context.asset_server().add(texture));
         }
@@ -169,11 +154,20 @@ impl AssetLoader for GLTFLoader {
             let mut primitives = Vec::new();
             let mut materials = Vec::new();
             for gltf_primitive in mesh.primitives() {
-                primitives.push(GLTFLoader::load_primitive(
-                    &buffers,
-                    &gltf_primitive,
-                    load_context.asset_server(),
-                )?);
+                primitives.push(
+                    GLTFLoader::load_primitive(
+                        &buffers,
+                        &gltf_primitive,
+                        load_context.asset_server(),
+                    )
+                    .with_context(|| {
+                        format!(
+                            "failed to load primitive {} of mesh '{}'",
+                            gltf_primitive.index(),
+                            mesh.name().unwrap_or("<unnamed>")
+                        )
+                    })?,
+                );
                 materials.push(gltf_primitive.material().index());
             }
 
@@ -315,11 +309,39 @@ impl AssetLoader for GLTFLoader {
 }
 
 impl GLTFLoader {
+    fn dynamic_image_from_gltf(data: gltf::image::Data) -> anyhow::Result<image::DynamicImage> {
+        let (width, height, format) = (data.width, data.height, data.format);
+        let buffer_error = || {
+            format!(
+                "image buffer does not match dimensions {}x{} for format {:?}",
+                width, height, format
+            )
+        };
+
+        let image = match format {
+            gltf::image::Format::R8 => image::DynamicImage::ImageLuma8(
+                ImageBuffer::from_vec(width, height, data.pixels).with_context(buffer_error)?,
+            ),
+            gltf::image::Format::R8G8 => image::DynamicImage::ImageLumaA8(
+                ImageBuffer::from_vec(width, height, data.pixels).with_context(buffer_error)?,
+            ),
+            gltf::image::Format::R8G8B8 => image::DynamicImage::ImageRgb8(
+                ImageBuffer::from_vec(width, height, data.pixels).with_context(buffer_error)?,
+            ),
+            gltf::image::Format::R8G8B8A8 => image::DynamicImage::ImageRgba8(
+                ImageBuffer::from_vec(width, height, data.pixels).with_context(buffer_error)?,
+            ),
+            format => bail!("unsupported GLTF image format {:?}", format),
+        };
+
+        Ok(image)
+    }
+
     fn load_primitive(
         buffers: &[Data],
         gltf_primitive: &Primitive,
         asset_server: &AssetServer,
-    ) -> Result<AssetHandle<Mesh>, ()> {
+    ) -> anyhow::Result<AssetHandle<Mesh>> {
         let mut primitive = Mesh {
             vertices: Vec::new(),
             indices: Vec::new(),
@@ -327,14 +349,17 @@ impl GLTFLoader {
 
         let reader = gltf_primitive.reader(|buffer| Some(&buffers[buffer.index()]));
 
-        primitive.indices = match reader.read_indices().ok_or(())? {
+        primitive.indices = match reader
+            .read_indices()
+            .context("GLTF primitive has no indices")?
+        {
             gltf::mesh::util::ReadIndices::U8(iter) => iter.map(|i| i as u32).collect(),
             gltf::mesh::util::ReadIndices::U16(iter) => iter.map(|i| i as u32).collect(),
             gltf::mesh::util::ReadIndices::U32(iter) => iter.collect(),
         };
         primitive.vertices = reader
             .read_positions()
-            .ok_or(())?
+            .context("GLTF primitive has no vertex positions")?
             .map(|pos| Vertex {
                 pos_coords: pos,
                 uv_coords: [0.0; 2],
@@ -353,7 +378,7 @@ impl GLTFLoader {
                         primitive.vertices[index].uv_coords = uvs;
                     });
                 }
-                _ => return Err(()),
+                _ => bail!("unsupported GLTF texture coordinate format (expected F32)"),
             }
         }
 
@@ -401,7 +426,7 @@ impl GLTFLoader {
                         primitive.vertices[index].bone_weights = weight;
                     });
                 }
-                _ => return Err(()),
+                _ => bail!("unsupported GLTF bone weight format (expected F32)"),
             }
         }
 

--- a/crates/gltf-loader/src/loader.rs
+++ b/crates/gltf-loader/src/loader.rs
@@ -10,7 +10,7 @@ use animation::{
     root::AnimationRootBone,
     target::AnimationTarget,
 };
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use async_trait::async_trait;
 use ecs::{
     command::CommandQueue,
@@ -118,8 +118,9 @@ impl AssetLoader for GLTFLoader {
         load_context: &mut essential::assets::asset_server::AssetLoadContext,
         usage_setting: <Self::Asset as essential::assets::LoadableAsset>::UsageSettings,
     ) -> anyhow::Result<Self::Asset> {
-        let (document, buffers, images) = gltf::import(path.to_path())
-            .with_context(|| format!("failed to import GLTF file '{}'", path.to_path().display()))?;
+        let (document, buffers, images) = gltf::import(path.to_path()).with_context(|| {
+            format!("failed to import GLTF file '{}'", path.to_path().display())
+        })?;
 
         let nodes = document
             .nodes()

--- a/crates/obj-loader/Cargo.toml
+++ b/crates/obj-loader/Cargo.toml
@@ -9,6 +9,7 @@ essential = { path = "../essential" }
 ecs = { path = "../ecs" }
 render = { path = "../render" }
 tobj = { version = "4.0.3", default-features = false, features = ["async"] }
+anyhow = "1.0.97"
 async-trait = "0.1.50"
 glam = { version = "0.30.1" }
 

--- a/crates/obj-loader/src/mtl_loader.rs
+++ b/crates/obj-loader/src/mtl_loader.rs
@@ -1,5 +1,6 @@
 use std::io::{BufReader, Cursor};
 
+use anyhow::Context;
 use async_trait::async_trait;
 use essential::assets::{
     Asset, AssetPath, LoadableAsset, asset_loader::AssetLoader, asset_server::AssetLoadContext,
@@ -34,36 +35,31 @@ impl AssetLoader for MTLLoader {
         path: AssetPath<'static>,
         load_context: &mut AssetLoadContext,
         _usage_setting: <Self::Asset as LoadableAsset>::UsageSettings,
-    ) -> Result<Self::Asset, ()> {
+    ) -> anyhow::Result<Self::Asset> {
         let obj_text = load_to_string(path.clone()).await?;
         let obj_cursor = Cursor::new(obj_text);
-        let mat = tobj::load_mtl_buf(&mut BufReader::new(obj_cursor));
+        let (mats, _) = tobj::load_mtl_buf(&mut BufReader::new(obj_cursor)).with_context(|| {
+            format!(
+                "failed to parse MTL file '{}'",
+                path.to_path().display()
+            )
+        })?;
 
-        match mat {
-            Ok((mats, _)) => {
-                let mut material = StandardMaterial::new(None, None);
-                for m in mats {
-                    if let Some(diffuse_texture) = m.diffuse_texture {
-                        let texture_handle =
-                            load_context.asset_server().load::<Texture>(diffuse_texture);
-                        material.set_diffuse_texture(texture_handle);
-                    }
-
-                    if let Some(normal_texture) = m.normal_texture {
-                        let texture_handle =
-                            load_context.asset_server().load::<Texture>(normal_texture);
-                        material.set_normal_texture(texture_handle);
-                    }
-                }
-
-                return Ok(MTLMaterial {
-                    material: load_context.asset_server().add(material),
-                });
+        let mut material = StandardMaterial::new(None, None);
+        for m in mats {
+            if let Some(diffuse_texture) = m.diffuse_texture {
+                let texture_handle = load_context.asset_server().load::<Texture>(diffuse_texture);
+                material.set_diffuse_texture(texture_handle);
             }
-            Err(_) => {
-                eprintln!("Failed to load MTL file: {}", path.to_path().display());
-                return Err(());
+
+            if let Some(normal_texture) = m.normal_texture {
+                let texture_handle = load_context.asset_server().load::<Texture>(normal_texture);
+                material.set_normal_texture(texture_handle);
             }
         }
+
+        Ok(MTLMaterial {
+            material: load_context.asset_server().add(material),
+        })
     }
 }

--- a/crates/obj-loader/src/mtl_loader.rs
+++ b/crates/obj-loader/src/mtl_loader.rs
@@ -38,12 +38,8 @@ impl AssetLoader for MTLLoader {
     ) -> anyhow::Result<Self::Asset> {
         let obj_text = load_to_string(path.clone()).await?;
         let obj_cursor = Cursor::new(obj_text);
-        let (mats, _) = tobj::load_mtl_buf(&mut BufReader::new(obj_cursor)).with_context(|| {
-            format!(
-                "failed to parse MTL file '{}'",
-                path.to_path().display()
-            )
-        })?;
+        let (mats, _) = tobj::load_mtl_buf(&mut BufReader::new(obj_cursor))
+            .with_context(|| format!("failed to parse MTL file '{}'", path.to_path().display()))?;
 
         let mut material = StandardMaterial::new(None, None);
         for m in mats {

--- a/crates/obj-loader/src/obj_loader.rs
+++ b/crates/obj-loader/src/obj_loader.rs
@@ -1,5 +1,6 @@
 use std::io::{BufRead, BufReader, Cursor};
 
+use anyhow::Context;
 use async_trait::async_trait;
 use ecs::{
     command::CommandQueue, component::Component, entity::Entity, query::Query, resource::Res,
@@ -63,9 +64,15 @@ impl AssetLoader for OBJLoader {
         path: AssetPath<'static>,
         load_context: &mut AssetLoadContext,
         _usage_setting: <Self::Asset as LoadableAsset>::UsageSettings,
-    ) -> Result<Self::Asset, ()> {
+    ) -> anyhow::Result<Self::Asset> {
         let obj_text = load_to_string(path.clone()).await?;
         let obj_cursor = Cursor::new(obj_text);
+
+        let obj_parent = path
+            .to_path()
+            .parent()
+            .context("OBJ path has no parent directory")?
+            .to_path_buf();
 
         let mat_handles = BufReader::new(obj_cursor.clone())
             .lines()
@@ -74,7 +81,7 @@ impl AssetLoader for OBJLoader {
                 if line.starts_with("mtllib") {
                     let parts: Vec<&str> = line.split_whitespace().collect();
                     if parts.len() > 1 {
-                        let mtl_path = path.to_path().parent().unwrap().join(parts[1]);
+                        let mtl_path = obj_parent.join(parts[1]);
                         Some(load_context.asset_server().load::<MTLMaterial>(mtl_path))
                     } else {
                         None
@@ -95,7 +102,12 @@ impl AssetLoader for OBJLoader {
             move |_| async move { Err(tobj::LoadError::GenericFailure) },
         )
         .await
-        .map_err(|_| ())?;
+        .with_context(|| {
+            format!(
+                "failed to parse OBJ file '{}'",
+                path.to_path().display()
+            )
+        })?;
 
         let meshes = models
             .iter()

--- a/crates/obj-loader/src/obj_loader.rs
+++ b/crates/obj-loader/src/obj_loader.rs
@@ -102,12 +102,7 @@ impl AssetLoader for OBJLoader {
             move |_| async move { Err(tobj::LoadError::GenericFailure) },
         )
         .await
-        .with_context(|| {
-            format!(
-                "failed to parse OBJ file '{}'",
-                path.to_path().display()
-            )
-        })?;
+        .with_context(|| format!("failed to parse OBJ file '{}'", path.to_path().display()))?;
 
         let meshes = models
             .iter()

--- a/crates/render/src/assets/texture.rs
+++ b/crates/render/src/assets/texture.rs
@@ -1,4 +1,5 @@
 use crate::loaders::texture_loader::TextureLoader;
+use anyhow::Context;
 use essential::assets::{Asset, LoadableAsset};
 use image::{DynamicImage, GenericImageView};
 use wgpu::TextureUsages;
@@ -41,9 +42,11 @@ pub struct Texture {
 }
 
 impl Texture {
-    #[allow(clippy::result_unit_err)]
-    pub fn from_bytes(bytes: &[u8], mut usage_settings: TextureUsageSettings) -> Result<Self, ()> {
-        let img = image::load_from_memory(bytes).map_err(|_| ())?;
+    pub fn from_bytes(
+        bytes: &[u8],
+        mut usage_settings: TextureUsageSettings,
+    ) -> anyhow::Result<Self> {
+        let img = image::load_from_memory(bytes).context("failed to decode image from bytes")?;
         let dimensions = img.dimensions();
 
         if usage_settings.texture_descriptor.size.width == 0

--- a/crates/render/src/loaders/texture_loader.rs
+++ b/crates/render/src/loaders/texture_loader.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use essential::assets::{
     asset_loader::AssetLoader, asset_server::AssetLoadContext, utils::load_binary, AssetPath,
     LoadableAsset,
@@ -19,22 +20,14 @@ impl AssetLoader for TextureLoader {
         path: AssetPath<'static>,
         _load_context: &mut AssetLoadContext,
         usage_settings: <Self::Asset as LoadableAsset>::UsageSettings,
-    ) -> Result<Self::Asset, ()> {
-        let data = load_binary(path).await;
+    ) -> anyhow::Result<Self::Asset> {
+        let data = load_binary(path.clone()).await?;
 
-        match data {
-            Ok(data) => {
-                let texture = Texture::from_bytes(&data, usage_settings);
-                match texture {
-                    Ok(texture) => {
-                        return Ok(texture);
-                    }
-                    Err(_) => {
-                        return Err(());
-                    }
-                }
-            }
-            Err(_) => Err(()),
-        }
+        Texture::from_bytes(&data, usage_settings).with_context(|| {
+            format!(
+                "failed to create texture from '{}'",
+                path.to_path().display()
+            )
+        })
     }
 }


### PR DESCRIPTION
## Summary

Asset load failures were invisible and sometimes fatal: the `AssetLoader` trait returned `Result<Asset, ()>`, so every loader discarded the real error from its underlying library (`gltf`, `tobj`, `image`, file I/O), and the asset server sent `LoadFailed` without logging anything. The GLTF loader even panicked on a missing file (`unwrap()` on `gltf::import`) and on unsupported image formats.

This PR threads the underlying library errors all the way to the logs using `anyhow`.

## Changes

- **`AssetLoader` trait** (`essential`): `load` now returns `anyhow::Result<Self::Asset>` instead of `Result<Self::Asset, ()>`.
- **Asset server**: failed loads are now logged with `log::error!`, including the asset path, the asset type, and the full `anyhow` error chain (`{:#}` formatting). The `AssetLoadEvent::LoadFailed` flow is otherwise unchanged.
- **GLTF loader**: `gltf::import` failures are propagated instead of panicking; unsupported image formats and image buffer mismatches return errors instead of `panic!`/`expect`; image conversion is factored into a `dynamic_image_from_gltf` helper; primitive loading errors carry the mesh name and primitive index, and missing indices/positions or unsupported texcoord/bone-weight formats are reported explicitly.
- **OBJ loader**: `tobj` parse errors are propagated with the file path; the `parent().unwrap()` on the OBJ path is now a proper error.
- **MTL loader**: `eprintln!` replaced with error propagation; `tobj::load_mtl_buf` errors carry the file path.
- **Texture loader / `Texture::from_bytes`**: `image` decode errors are propagated with the source path instead of being collapsed into `()`.
- **`load_to_string` / `load_binary`** (`essential`): return `anyhow::Result` with the file path (native) or URL (wasm) in the error context; no more `unwrap()` on `current_exe()`.
- Added `anyhow` to the `gltf-loader` and `obj-loader` manifests.

## Example

Loading a missing GLTF file previously panicked. It now logs:

```
ERROR essential::assets::asset_server] Failed to load asset 'res/does_not_exist.gltf' (type gltf_loader::loader::GLTFScene): failed to import GLTF file 'res/does_not_exist.gltf': No such file or directory (os error 2)
```

## Testing

- `cargo check --workspace` passes
- `cargo clippy --workspace` — no new warnings (all remaining warnings are pre-existing)
- `cargo test --workspace` passes
- Verified end-to-end with a temporary binary that loads a nonexistent `.gltf` and confirms the error above reaches the log output

https://claude.ai/code/session_01K4zx3ufmAvW6qUhxCJY44c

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4zx3ufmAvW6qUhxCJY44c)_