### PR TITLE
Migrate StandardMaterial from Blinn-Phong to PBR (metallic/roughness)

### DIFF
--- a/crates/gltf-loader/src/loader.rs
+++ b/crates/gltf-loader/src/loader.rs
@@ -26,7 +26,7 @@ use essential::{
     },
     transform::Transform,
 };
-use glam::Mat4;
+use glam::{Mat4, Vec3, Vec4};
 use gltf::{Node, Primitive, buffer::Data};
 
 use image::ImageBuffer;
@@ -127,25 +127,60 @@ impl AssetLoader for GLTFLoader {
             .map(|node| GLTFLoader::extract_node(&node))
             .collect();
 
-        let mut textures = Vec::new();
+        let mut decoded_images = Vec::new();
         for (image_index, data) in images.into_iter().enumerate() {
             let image = GLTFLoader::dynamic_image_from_gltf(data)
                 .with_context(|| format!("failed to load GLTF image at index {}", image_index))?;
-            let texture = Texture::from_dynamic_image(image);
-            textures.push(load_context.asset_server().add(texture));
+            decoded_images.push(image);
         }
+
+        // Color textures (base color, emissive) are sRGB-encoded while data
+        // textures (normal, metallic-roughness, occlusion) are linear.  An
+        // image can be referenced in both roles, so texture assets are
+        // created lazily per (image, color space) pair.
+        let mut texture_cache: HashMap<(usize, bool), AssetHandle<Texture>> = HashMap::new();
+        let mut texture_handle = |texture: gltf::Texture<'_>, srgb: bool| {
+            let image_index = texture.source().index();
+            texture_cache
+                .entry((image_index, srgb))
+                .or_insert_with(|| {
+                    let image = decoded_images[image_index].clone();
+                    let texture = if srgb {
+                        Texture::from_dynamic_image(image)
+                    } else {
+                        Texture::from_dynamic_image_linear(image)
+                    };
+                    load_context.asset_server().add(texture)
+                })
+                .clone()
+        };
 
         let mut materials = Vec::new();
         for gltf_material in document.materials() {
-            let material = StandardMaterial::new(
-                gltf_material
-                    .pbr_metallic_roughness()
-                    .base_color_texture()
-                    .map(|texture| textures[texture.texture().source().index()].clone()),
+            let pbr = gltf_material.pbr_metallic_roughness();
+            let mut material = StandardMaterial::new(
+                pbr.base_color_texture()
+                    .map(|info| texture_handle(info.texture(), true)),
                 gltf_material
                     .normal_texture()
-                    .map(|texture| textures[texture.texture().source().index()].clone()),
+                    .map(|info| texture_handle(info.texture(), false)),
             );
+
+            material.set_base_color_factor(Vec4::from_array(pbr.base_color_factor()));
+            material.set_metallic_factor(pbr.metallic_factor());
+            material.set_roughness_factor(pbr.roughness_factor());
+            material.set_emissive_factor(Vec3::from_array(gltf_material.emissive_factor()));
+
+            if let Some(info) = pbr.metallic_roughness_texture() {
+                material.set_metallic_roughness_texture(texture_handle(info.texture(), false));
+            }
+            if let Some(info) = gltf_material.emissive_texture() {
+                material.set_emissive_texture(texture_handle(info.texture(), true));
+            }
+            if let Some(info) = gltf_material.occlusion_texture() {
+                material.set_occlusion_strength(info.strength());
+                material.set_occlusion_texture(texture_handle(info.texture(), false));
+            }
 
             materials.push(load_context.asset_server().add(material));
         }
@@ -391,7 +426,14 @@ impl GLTFLoader {
 
         if let Some(tangents) = reader.read_tangents() {
             tangents.enumerate().for_each(|(index, tangent)| {
-                primitive.vertices[index].tangent = [tangent[0], tangent[1], tangent[2]];
+                let vertex = &mut primitive.vertices[index];
+                vertex.tangent = [tangent[0], tangent[1], tangent[2]];
+                // GLTF tangents are vec4; w stores the handedness sign used
+                // to reconstruct the bitangent.
+                let bitangent = Vec3::from_array(vertex.normal)
+                    .cross(Vec3::new(tangent[0], tangent[1], tangent[2]))
+                    * tangent[3];
+                vertex.bitangent = bitangent.to_array();
             });
         }
 

--- a/crates/obj-loader/src/mtl_loader.rs
+++ b/crates/obj-loader/src/mtl_loader.rs
@@ -63,8 +63,9 @@ impl AssetLoader for MTLLoader {
             }
 
             if let Some(diffuse) = m.diffuse {
-                material
-                    .set_base_color_factor(glam::Vec4::new(diffuse[0], diffuse[1], diffuse[2], 1.0));
+                material.set_base_color_factor(glam::Vec4::new(
+                    diffuse[0], diffuse[1], diffuse[2], 1.0,
+                ));
             }
 
             if let Some(shininess) = m.shininess {

--- a/crates/obj-loader/src/mtl_loader.rs
+++ b/crates/obj-loader/src/mtl_loader.rs
@@ -7,7 +7,10 @@ use essential::assets::{
     handle::AssetHandle, utils::load_to_string,
 };
 
-use render::assets::{material::StandardMaterial, texture::Texture};
+use render::assets::{
+    material::StandardMaterial,
+    texture::{Texture, TextureUsageSettings},
+};
 
 #[derive(Asset)]
 pub struct MTLMaterial {
@@ -45,12 +48,28 @@ impl AssetLoader for MTLLoader {
         for m in mats {
             if let Some(diffuse_texture) = m.diffuse_texture {
                 let texture_handle = load_context.asset_server().load::<Texture>(diffuse_texture);
-                material.set_diffuse_texture(texture_handle);
+                material.set_base_color_texture(texture_handle);
             }
 
             if let Some(normal_texture) = m.normal_texture {
-                let texture_handle = load_context.asset_server().load::<Texture>(normal_texture);
+                // Normal maps store directions, not colors; load linear.
+                let texture_handle = load_context
+                    .asset_server()
+                    .load_with_usage_settings::<Texture>(
+                        normal_texture,
+                        TextureUsageSettings::linear(),
+                    );
                 material.set_normal_texture(texture_handle);
+            }
+
+            if let Some(diffuse) = m.diffuse {
+                material
+                    .set_base_color_factor(glam::Vec4::new(diffuse[0], diffuse[1], diffuse[2], 1.0));
+            }
+
+            if let Some(shininess) = m.shininess {
+                // Map Blinn-Phong shininess to an equivalent GGX roughness.
+                material.set_roughness_factor((2.0 / (shininess + 2.0)).sqrt().clamp(0.045, 1.0));
             }
         }
 

--- a/crates/render/src/assets/material.rs
+++ b/crates/render/src/assets/material.rs
@@ -1,5 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use essential::assets::{handle::AssetHandle, Asset};
+use glam::{Vec3, Vec4};
 use render_macros::AsBindGroup;
 
 use crate::{
@@ -18,7 +19,7 @@ use bitflags::bitflags;
 
 /// A reference to a WGSL shader source.
 ///
-/// Pass [`ShaderRef::Default`] to use the engine's built-in Phong shader, or
+/// Pass [`ShaderRef::Default`] to use the engine's built-in PBR shader, or
 /// [`ShaderRef::Source`] to supply your own WGSL source string.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ShaderRef {
@@ -87,15 +88,20 @@ pub trait AsBindGroup {
     ) -> Result<wgpu::BindGroup, AssetPreparationError>;
 }
 
-// // ────────────────────────────────────────────────────────────────────────────
-// // StandardMaterial — the engine's built-in Phong material
-// // ────────────────────────────────────────────────────────────────────────────
+// ────────────────────────────────────────────────────────────────────────────
+// StandardMaterial — the engine's built-in PBR material
+// ────────────────────────────────────────────────────────────────────────────
 
-// /// The engine's built-in Phong-shaded material with optional diffuse and normal
-// /// maps.
-// ///
-// /// Use this as a starting point, or define your own material by implementing
-// /// [`AsBindGroup`] (manually or via `#[derive(AsBindGroup)]`).
+/// The engine's built-in physically based (metallic/roughness) material.
+///
+/// Follows the glTF PBR conventions: the metallic-roughness texture stores
+/// roughness in the green channel and metalness in the blue channel, and the
+/// occlusion texture stores ambient occlusion in the red channel.  Texture
+/// samples are multiplied by the corresponding scalar factors, so untextured
+/// materials are fully described by the factors alone.
+///
+/// Use this as a starting point, or define your own material by implementing
+/// [`AsBindGroup`] (manually or via `#[derive(AsBindGroup)]`).
 #[derive(Asset, AsBindGroup)]
 #[material(
     vertex_shader = include_str!("../shaders/shader.wgsl"),
@@ -104,56 +110,185 @@ pub trait AsBindGroup {
 pub struct StandardMaterial {
     #[texture(0)]
     #[sampler(1)]
-    diffuse_texture: Option<AssetHandle<Texture>>,
+    base_color_texture: Option<AssetHandle<Texture>>,
 
     #[texture(2)]
     #[sampler(3)]
     normal_texture: Option<AssetHandle<Texture>>,
 
-    #[uniform(4)]
-    flags: MaterialUniform,
+    #[texture(4)]
+    #[sampler(5)]
+    metallic_roughness_texture: Option<AssetHandle<Texture>>,
+
+    #[texture(6)]
+    #[sampler(7)]
+    emissive_texture: Option<AssetHandle<Texture>>,
+
+    #[texture(8)]
+    #[sampler(9)]
+    occlusion_texture: Option<AssetHandle<Texture>>,
+
+    #[uniform(10)]
+    uniform: MaterialUniform,
+}
+
+impl Default for StandardMaterial {
+    fn default() -> Self {
+        Self {
+            base_color_texture: None,
+            normal_texture: None,
+            metallic_roughness_texture: None,
+            emissive_texture: None,
+            occlusion_texture: None,
+            uniform: MaterialUniform::default(),
+        }
+    }
 }
 
 impl StandardMaterial {
     pub fn new(
-        diffuse_texture: Option<AssetHandle<Texture>>,
+        base_color_texture: Option<AssetHandle<Texture>>,
         normal_texture: Option<AssetHandle<Texture>>,
     ) -> Self {
-        let mut flag_bits = MaterialFlags::empty();
-        if diffuse_texture.is_some() {
-            flag_bits |= MaterialFlags::HAS_DIFFUSE_TEXTURE;
+        let mut material = Self::default();
+        if let Some(texture) = base_color_texture {
+            material.set_base_color_texture(texture);
         }
-        if normal_texture.is_some() {
-            flag_bits |= MaterialFlags::HAS_NORMAL_TEXTURE;
+        if let Some(texture) = normal_texture {
+            material.set_normal_texture(texture);
         }
-
-        Self {
-            diffuse_texture,
-            normal_texture,
-            flags: MaterialUniform {
-                flags: flag_bits,
-                _padding: [0; 3],
-                _padding2: [0; 4],
-            },
-        }
+        material
     }
 
+    pub fn with_base_color_factor(mut self, factor: Vec4) -> Self {
+        self.set_base_color_factor(factor);
+        self
+    }
+
+    pub fn with_metallic_roughness_texture(mut self, texture: AssetHandle<Texture>) -> Self {
+        self.set_metallic_roughness_texture(texture);
+        self
+    }
+
+    pub fn with_emissive_texture(mut self, texture: AssetHandle<Texture>) -> Self {
+        self.set_emissive_texture(texture);
+        self
+    }
+
+    pub fn with_occlusion_texture(mut self, texture: AssetHandle<Texture>) -> Self {
+        self.set_occlusion_texture(texture);
+        self
+    }
+
+    pub fn set_base_color_texture(&mut self, texture: AssetHandle<Texture>) {
+        self.base_color_texture = Some(texture);
+        self.uniform.flags |= MaterialFlags::HAS_BASE_COLOR_TEXTURE;
+    }
+
+    pub fn base_color_texture(&self) -> Option<&AssetHandle<Texture>> {
+        self.base_color_texture.as_ref()
+    }
+
+    #[deprecated(note = "renamed to `set_base_color_texture`")]
     pub fn set_diffuse_texture(&mut self, texture: AssetHandle<Texture>) {
-        self.diffuse_texture = Some(texture);
+        self.set_base_color_texture(texture);
     }
 
+    #[deprecated(note = "renamed to `base_color_texture`")]
     pub fn diffuse_texture(&self) -> Option<&AssetHandle<Texture>> {
-        self.diffuse_texture.as_ref()
+        self.base_color_texture()
     }
 
     pub fn set_normal_texture(&mut self, texture: AssetHandle<Texture>) {
         self.normal_texture = Some(texture);
+        self.uniform.flags |= MaterialFlags::HAS_NORMAL_TEXTURE;
     }
 
     pub fn normal_texture(&self) -> Option<&AssetHandle<Texture>> {
         self.normal_texture.as_ref()
     }
+
+    pub fn set_metallic_roughness_texture(&mut self, texture: AssetHandle<Texture>) {
+        self.metallic_roughness_texture = Some(texture);
+        self.uniform.flags |= MaterialFlags::HAS_METALLIC_ROUGHNESS_TEXTURE;
+    }
+
+    pub fn metallic_roughness_texture(&self) -> Option<&AssetHandle<Texture>> {
+        self.metallic_roughness_texture.as_ref()
+    }
+
+    pub fn set_emissive_texture(&mut self, texture: AssetHandle<Texture>) {
+        self.emissive_texture = Some(texture);
+        self.uniform.flags |= MaterialFlags::HAS_EMISSIVE_TEXTURE;
+    }
+
+    pub fn emissive_texture(&self) -> Option<&AssetHandle<Texture>> {
+        self.emissive_texture.as_ref()
+    }
+
+    pub fn set_occlusion_texture(&mut self, texture: AssetHandle<Texture>) {
+        self.occlusion_texture = Some(texture);
+        self.uniform.flags |= MaterialFlags::HAS_OCCLUSION_TEXTURE;
+    }
+
+    pub fn occlusion_texture(&self) -> Option<&AssetHandle<Texture>> {
+        self.occlusion_texture.as_ref()
+    }
+
+    /// Multiplied with the base color texture (or used directly when no
+    /// texture is set).  Linear RGBA; defaults to white.
+    pub fn set_base_color_factor(&mut self, factor: Vec4) {
+        self.uniform.base_color_factor = factor.to_array();
+    }
+
+    pub fn base_color_factor(&self) -> Vec4 {
+        Vec4::from_array(self.uniform.base_color_factor)
+    }
+
+    /// Multiplied with the blue channel of the metallic-roughness texture.
+    /// Defaults to `0.0`.
+    pub fn set_metallic_factor(&mut self, factor: f32) {
+        self.uniform.metallic_factor = factor;
+    }
+
+    pub fn metallic_factor(&self) -> f32 {
+        self.uniform.metallic_factor
+    }
+
+    /// Multiplied with the green channel of the metallic-roughness texture.
+    /// Defaults to `0.5`.
+    pub fn set_roughness_factor(&mut self, factor: f32) {
+        self.uniform.roughness_factor = factor;
+    }
+
+    pub fn roughness_factor(&self) -> f32 {
+        self.uniform.roughness_factor
+    }
+
+    /// Multiplied with the emissive texture (or used directly when no texture
+    /// is set).  Linear RGB; defaults to black (no emission).
+    pub fn set_emissive_factor(&mut self, factor: Vec3) {
+        self.uniform.emissive_factor = factor.to_array();
+    }
+
+    pub fn emissive_factor(&self) -> Vec3 {
+        Vec3::from_array(self.uniform.emissive_factor)
+    }
+
+    /// Blends the occlusion texture's effect from none (`0.0`) to full
+    /// (`1.0`, the default).
+    pub fn set_occlusion_strength(&mut self, strength: f32) {
+        self.uniform.occlusion_strength = strength;
+    }
+
+    pub fn occlusion_strength(&self) -> f32 {
+        self.uniform.occlusion_strength
+    }
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// MaterialFlags / MaterialUniform (used by StandardMaterial)
+// ────────────────────────────────────────────────────────────────────────────
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
@@ -161,17 +296,43 @@ pub struct MaterialFlags(u32);
 
 bitflags! {
     impl MaterialFlags: u32 {
-        const HAS_DIFFUSE_TEXTURE = 1 << 0;
+        const HAS_BASE_COLOR_TEXTURE = 1 << 0;
         const HAS_NORMAL_TEXTURE = 1 << 1;
+        const HAS_METALLIC_ROUGHNESS_TEXTURE = 1 << 2;
+        const HAS_EMISSIVE_TEXTURE = 1 << 3;
+        const HAS_OCCLUSION_TEXTURE = 1 << 4;
     }
 }
 
+/// GPU-side material parameters.  The field order and padding must match the
+/// `MaterialUniform` struct in `shaders/shader.wgsl` (WGSL uniform layout:
+/// `vec4` and `vec3` align to 16 bytes, scalars pack into the `vec3` tail).
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub(crate) struct MaterialUniform {
-    pub(crate) flags: MaterialFlags,
-    pub(crate) _padding: [u32; 3],
-    pub(crate) _padding2: [u32; 4],
+    base_color_factor: [f32; 4],
+    emissive_factor: [f32; 3],
+    metallic_factor: f32,
+    roughness_factor: f32,
+    occlusion_strength: f32,
+    flags: MaterialFlags,
+    _padding: u32,
+}
+
+const _: () = assert!(std::mem::size_of::<MaterialUniform>() == 48);
+
+impl Default for MaterialUniform {
+    fn default() -> Self {
+        Self {
+            base_color_factor: [1.0; 4],
+            emissive_factor: [0.0; 3],
+            metallic_factor: 0.0,
+            roughness_factor: 0.5,
+            occlusion_strength: 1.0,
+            flags: MaterialFlags::empty(),
+            _padding: 0,
+        }
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/render/src/assets/material.rs
+++ b/crates/render/src/assets/material.rs
@@ -102,7 +102,7 @@ pub trait AsBindGroup {
 ///
 /// Use this as a starting point, or define your own material by implementing
 /// [`AsBindGroup`] (manually or via `#[derive(AsBindGroup)]`).
-#[derive(Asset, AsBindGroup)]
+#[derive(Asset, AsBindGroup, Default)]
 #[material(
     vertex_shader = include_str!("../shaders/shader.wgsl"),
     fragment_shader = include_str!("../shaders/shader.wgsl")
@@ -130,19 +130,6 @@ pub struct StandardMaterial {
 
     #[uniform(10)]
     uniform: MaterialUniform,
-}
-
-impl Default for StandardMaterial {
-    fn default() -> Self {
-        Self {
-            base_color_texture: None,
-            normal_texture: None,
-            metallic_roughness_texture: None,
-            emissive_texture: None,
-            occlusion_texture: None,
-            uniform: MaterialUniform::default(),
-        }
-    }
 }
 
 impl StandardMaterial {

--- a/crates/render/src/assets/texture.rs
+++ b/crates/render/src/assets/texture.rs
@@ -35,6 +35,16 @@ impl Default for TextureUsageSettings {
     }
 }
 
+impl TextureUsageSettings {
+    /// Settings for non-color data textures (normal maps, metallic-roughness,
+    /// occlusion).  These must not be sRGB-decoded when sampled.
+    pub fn linear() -> Self {
+        let mut settings = Self::default();
+        settings.texture_descriptor.format = TextureFormat::Rgba8Unorm;
+        settings
+    }
+}
+
 #[derive(Asset)]
 pub struct Texture {
     data: Vec<u8>,
@@ -88,6 +98,20 @@ impl Texture {
     }
 
     pub fn from_dynamic_image(image: DynamicImage) -> Self {
+        Self::from_dynamic_image_with_format(image, TextureFormat::Rgba8UnormSrgb)
+    }
+
+    /// Like [`Texture::from_dynamic_image`], but for non-color data textures
+    /// (normal maps, metallic-roughness, occlusion) that must not be
+    /// sRGB-decoded when sampled.
+    pub fn from_dynamic_image_linear(image: DynamicImage) -> Self {
+        Self::from_dynamic_image_with_format(image, TextureFormat::Rgba8Unorm)
+    }
+
+    /// Like [`Texture::from_dynamic_image`], but with an explicit texture
+    /// format.  Use [`TextureFormat::Rgba8Unorm`] for non-color data such as
+    /// normal maps, metallic-roughness, and occlusion textures.
+    pub fn from_dynamic_image_with_format(image: DynamicImage, format: TextureFormat) -> Self {
         let mut usage_settings = TextureUsageSettings::default();
 
         let extent = Extent3d {
@@ -97,7 +121,7 @@ impl Texture {
         };
 
         usage_settings.texture_descriptor.size = extent;
-        usage_settings.texture_descriptor.format = TextureFormat::Rgba8UnormSrgb;
+        usage_settings.texture_descriptor.format = format;
 
         Self {
             data: image.to_rgba8().into_raw(),

--- a/crates/render/src/shaders/shader.wgsl
+++ b/crates/render/src/shaders/shader.wgsl
@@ -1,18 +1,29 @@
-const TOON_LEVELS = 3.0; // Number of color bands
-
 const MAX_LIGHT_COUNT : i32 = 128;
 const MAX_BONE_COUNT : i32 = 128;
 
-const HAS_DIFFUSE_TEXTURE = 1u << 0u;
+const HAS_BASE_COLOR_TEXTURE = 1u << 0u;
 const HAS_NORMAL_TEXTURE = 1u << 1u;
+const HAS_METALLIC_ROUGHNESS_TEXTURE = 1u << 2u;
+const HAS_EMISSIVE_TEXTURE = 1u << 3u;
+const HAS_OCCLUSION_TEXTURE = 1u << 4u;
 
 const POINT_LIGHT = 0u;
 const SPOT_LIGHT = 1u;
 const DIRECTIONAL_LIGHT = 2u;
 
-struct MaterialFlags {
+const PI = 3.14159265359;
+const AMBIENT_INTENSITY = 0.03;
+// Roughness below this produces a near-singular specular lobe.
+const MIN_ROUGHNESS = 0.045;
+
+struct MaterialUniform {
+    base_color_factor: vec4<f32>,
+    emissive_factor: vec3<f32>,
+    metallic_factor: f32,
+    roughness_factor: f32,
+    occlusion_strength: f32,
     flags: u32,
-    _padding: vec3<u32>, // Adds 12 bytes padding to reach 16 bytes
+    _padding: u32,
 }
 
 struct Light {
@@ -110,15 +121,27 @@ fn vs_main(
 
 // Fragment shader
 @group(0) @binding(0)
-var t_diffuse: texture_2d<f32>;
+var t_base_color: texture_2d<f32>;
 @group(0) @binding(1)
-var s_diffuse: sampler;
+var s_base_color: sampler;
 @group(0) @binding(2)
 var t_normal: texture_2d<f32>;
 @group(0) @binding(3)
 var s_normal: sampler;
 @group(0) @binding(4)
-var<uniform> material_flags: MaterialFlags;
+var t_metallic_roughness: texture_2d<f32>;
+@group(0) @binding(5)
+var s_metallic_roughness: sampler;
+@group(0) @binding(6)
+var t_emissive: texture_2d<f32>;
+@group(0) @binding(7)
+var s_emissive: sampler;
+@group(0) @binding(8)
+var t_occlusion: texture_2d<f32>;
+@group(0) @binding(9)
+var s_occlusion: sampler;
+@group(0) @binding(10)
+var<uniform> material: MaterialUniform;
 
 @group(1) @binding(0)
 var<uniform> camera: CameraUniform;
@@ -131,20 +154,30 @@ var<uniform> bones: Skeleton;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    return phong_fs(in);
+    return pbr_fs(in);
 }
 
-fn phong_fs(in: VertexOutput) -> vec4<f32> {
-    let object_color: vec4<f32> = sample_diffuse(in.tex_coords);
-    let object_normal: vec4<f32> = sample_normal(in.tex_coords);
+fn pbr_fs(in: VertexOutput) -> vec4<f32> {
+    let base_color = sample_base_color(in.tex_coords) * material.base_color_factor;
+    let metallic_roughness = sample_metallic_roughness(in.tex_coords);
+    let metallic = metallic_roughness.b * material.metallic_factor;
+    let roughness = clamp(metallic_roughness.g * material.roughness_factor, MIN_ROUGHNESS, 1.0);
+    let occlusion = mix(1.0, sample_occlusion(in.tex_coords).r, material.occlusion_strength);
+    let emissive = sample_emissive(in.tex_coords).rgb * material.emissive_factor;
 
-     // Normal mapping calculations
+    // Normal mapping calculations
+    let object_normal = sample_normal(in.tex_coords);
     let TBN = mat3x3<f32>(in.world_tangent, in.world_bitangent, in.world_normal);
     let mapped_normal = normalize(TBN * normalize(object_normal.xyz * 2.0 - 1.0));
 
     let view_dir = normalize(camera.view_pos - in.world_position);
+    let NdotV = max(dot(mapped_normal, view_dir), 1e-4);
 
-    var total_light = object_color * 0.1;
+    // Dielectrics reflect ~4% at normal incidence; metals reflect base color.
+    let f0 = mix(vec3<f32>(0.04), base_color.rgb, metallic);
+    let diffuse_color = base_color.rgb * (1.0 - metallic);
+
+    var total_light = vec3<f32>(0.0);
 
     for (var i: i32 = 0; i < min(lights.light_count, MAX_LIGHT_COUNT); i = i + 1) {
 
@@ -160,45 +193,107 @@ fn phong_fs(in: VertexOutput) -> vec4<f32> {
             light_dir = normalize(light_delta);
         }
 
-        // Simple Lambertian diffuse
-        let NdotL = max(dot(mapped_normal, light_dir), 0.0);
-        let diffuse = object_color * NdotL;
-
-        // Simple Blinn-Phong specular
-        let halfway_dir = normalize(light_dir + view_dir);
-        let specular = pow(max(dot(mapped_normal, halfway_dir), 0.0), 32.0);
-
-        var attenuation = light.intensity;
-        if light_type == POINT_LIGHT {
-            let light_distance = length(light_delta);
-            attenuation /= light_distance * light_distance;
-        } else if light_type == SPOT_LIGHT {
+        var attenuation = 1.0;
+        if light_type != DIRECTIONAL_LIGHT {
+            let light_distance_sq = dot(light_delta, light_delta);
+            attenuation = 1.0 / max(light_distance_sq, 1e-4);
+        }
+        if light_type == SPOT_LIGHT {
             let cone_dir = normalize(light.direction.xyz);
-            let angle_cos = dot(light_dir, cone_dir);
-            let light_distance = length(light_delta);
-            attenuation /= light_distance * light_distance;            
-            attenuation *= step(light.cos_cone_angle, angle_cos);
+            let angle_cos = dot(light_dir, -cone_dir);
+            let cone_edge_softness = mix(light.cos_cone_angle, 1.0, 0.2);
+            attenuation *= smoothstep(light.cos_cone_angle, cone_edge_softness, angle_cos);
         }
 
-        total_light += (diffuse + specular) * attenuation;
+        let radiance = light.color.rgb * light.intensity * attenuation;
+
+        let NdotL = max(dot(mapped_normal, light_dir), 0.0);
+        let halfway_dir = normalize(light_dir + view_dir);
+        let NdotH = max(dot(mapped_normal, halfway_dir), 0.0);
+        let HdotV = max(dot(halfway_dir, view_dir), 0.0);
+
+        // Cook-Torrance specular BRDF
+        let D = distribution_ggx(NdotH, roughness);
+        let G = geometry_smith(NdotV, NdotL, roughness);
+        let F = fresnel_schlick(HdotV, f0);
+        let specular = (D * G * F) / max(4.0 * NdotV * NdotL, 1e-4);
+
+        // Energy not reflected as specular diffuses (none for metals)
+        let kd = (vec3<f32>(1.0) - F) * (1.0 - metallic);
+
+        total_light += (kd * diffuse_color / PI + specular) * radiance * NdotL;
     }
 
-    return vec4<f32>(total_light.rgb, object_color.a);
+    let ambient = AMBIENT_INTENSITY * base_color.rgb * occlusion;
+    let color = ambient + total_light + emissive;
+
+    // Tone map to LDR; the sRGB surface format applies gamma encoding.
+    return vec4<f32>(aces_tonemap(color), base_color.a);
 }
 
+// Trowbridge-Reitz GGX normal distribution
+fn distribution_ggx(NdotH: f32, roughness: f32) -> f32 {
+    let a = roughness * roughness;
+    let a2 = a * a;
+    let f = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    return a2 / (PI * f * f);
+}
 
-fn sample_diffuse(tex_coords: vec2<f32>) -> vec4<f32> {
-    if (material_flags.flags & HAS_DIFFUSE_TEXTURE) != 0u {
-        return textureSample(t_diffuse, s_diffuse, tex_coords);
+// Smith geometry term with Schlick-GGX, k remapped for analytic lights
+fn geometry_smith(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
+    let r = roughness + 1.0;
+    let k = (r * r) / 8.0;
+    let ggx_v = NdotV / (NdotV * (1.0 - k) + k);
+    let ggx_l = NdotL / (NdotL * (1.0 - k) + k);
+    return ggx_v * ggx_l;
+}
+
+fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
+    return f0 + (vec3<f32>(1.0) - f0) * pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
+}
+
+// Narkowicz ACES filmic approximation
+fn aces_tonemap(color: vec3<f32>) -> vec3<f32> {
+    let mapped = (color * (2.51 * color + 0.03)) / (color * (2.43 * color + 0.59) + 0.14);
+    return clamp(mapped, vec3<f32>(0.0), vec3<f32>(1.0));
+}
+
+fn sample_base_color(tex_coords: vec2<f32>) -> vec4<f32> {
+    if (material.flags & HAS_BASE_COLOR_TEXTURE) != 0u {
+        return textureSample(t_base_color, s_base_color, tex_coords);
     } else {
-        return vec4<f32>(1.0, 0.0, 1.0, 1.0); // Default Magenta
+        return vec4<f32>(1.0);
     }
 }
 
 fn sample_normal(tex_coords: vec2<f32>) -> vec4<f32> {
-    if (material_flags.flags & HAS_NORMAL_TEXTURE) != 0u {
+    if (material.flags & HAS_NORMAL_TEXTURE) != 0u {
         return textureSample(t_normal, s_normal, tex_coords);
     } else {
         return vec4<f32>(0.5, 0.5, 1.0, 1.0); // Default flat normal
+    }
+}
+
+fn sample_metallic_roughness(tex_coords: vec2<f32>) -> vec4<f32> {
+    if (material.flags & HAS_METALLIC_ROUGHNESS_TEXTURE) != 0u {
+        return textureSample(t_metallic_roughness, s_metallic_roughness, tex_coords);
+    } else {
+        return vec4<f32>(1.0); // Factors apply unmodified
+    }
+}
+
+fn sample_emissive(tex_coords: vec2<f32>) -> vec4<f32> {
+    if (material.flags & HAS_EMISSIVE_TEXTURE) != 0u {
+        return textureSample(t_emissive, s_emissive, tex_coords);
+    } else {
+        return vec4<f32>(1.0); // Factor applies unmodified
+    }
+}
+
+fn sample_occlusion(tex_coords: vec2<f32>) -> vec4<f32> {
+    if (material.flags & HAS_OCCLUSION_TEXTURE) != 0u {
+        return textureSample(t_occlusion, s_occlusion, tex_coords);
+    } else {
+        return vec4<f32>(1.0); // Unoccluded
     }
 }

--- a/examples/render-test/src/main.rs
+++ b/examples/render-test/src/main.rs
@@ -124,11 +124,15 @@ fn spawn_camera_terminal(
 
 #[cfg(not(feature = "terminal"))]
 fn spawn_camera_windowed(mut cmd: CommandQueue) {
-    spawn_first_person_player(&mut cmd, Vec3::new(0.0, 2.0, 0.0),  Light {
+    spawn_first_person_player(
+        &mut cmd,
+        Vec3::new(0.0, 2.0, 0.0),
+        Light {
             color: Vec4::new(1.0, 1.0, 1.0, 1.0),
-            intensity: 100.0,
+            intensity: 10.0,
             light_type: LighType::Point,
-        });
+        },
+    );
 }
 
 fn spawn_scene(mut cmd: CommandQueue, asset_server: Res<AssetServer>) {

--- a/examples/render-test/src/main.rs
+++ b/examples/render-test/src/main.rs
@@ -124,40 +124,14 @@ fn spawn_camera_terminal(
 
 #[cfg(not(feature = "terminal"))]
 fn spawn_camera_windowed(mut cmd: CommandQueue) {
-    spawn_first_person_player(&mut cmd, Vec3::new(0.0, 2.0, 0.0), ());
+    spawn_first_person_player(&mut cmd, Vec3::new(0.0, 2.0, 0.0),  Light {
+            color: Vec4::new(1.0, 1.0, 1.0, 1.0),
+            intensity: 100.0,
+            light_type: LighType::Point,
+        });
 }
 
 fn spawn_scene(mut cmd: CommandQueue, asset_server: Res<AssetServer>) {
-    let mesh = asset_server.add(make_cube());
-    let material = asset_server.add(StandardMaterial::new(None, None));
-    cmd.spawn((
-        Cube,
-        MeshComponent { handle: mesh },
-        MaterialComponent::<StandardMaterial> { handle: material },
-        Transform::from_translation_rotation(
-            Vec3::X * 2.0 + Vec3::Y * 2.0 + -Vec3::Z * 2.0,
-            Quat::IDENTITY,
-        ),
-    ));
-
-    let light = Light {
-        color: Vec4::new(1.0, 0.0, 1.0, 1.0),
-        intensity: 10.0,
-        light_type: LighType::Spot(SpotLight {
-            cone_angle: 50.0 * PI / 180.0,
-        }),
-    };
-    let mut light_transform =
-        Transform::from_translation_rotation(Vec3::new(0.0, 2.0, 0.0), Quat::IDENTITY);
-    light_transform.look_at(Vec3::ZERO, Vec3::Y);
-
-    cmd.spawn(GizmoSphere {
-        center: light_transform.translation,
-        radius: 0.1,
-        color: LinearRgba::GREEN,
-    });
-    cmd.spawn((light, light_transform));
-
     cmd.spawn(GLTFSpawnerComponent(asset_server.load(SPONZA_PATH)));
 }
 


### PR DESCRIPTION
- Cook-Torrance specular (GGX + Smith + Fresnel-Schlick) with Lambertian
  diffuse, ACES tone mapping, and physical inverse-square attenuation
- StandardMaterial gains metallic-roughness, emissive, and occlusion
  textures plus scalar factors (base color, metallic, roughness,
  emissive, occlusion strength)
- Lights now apply their color and intensity; directional lights use the
  correct type index; spot cones get smooth falloff
- Non-color textures (normal, metallic-roughness, occlusion) load as
  linear instead of sRGB
- GLTF loader extracts full PBR material data and reconstructs
  bitangents from tangent handedness
- MTL loader maps diffuse color and shininess to PBR factors

https://claude.ai/code/session_01PMoePFP1ATJ2dvXwHjrHqg